### PR TITLE
Removed first character of your .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-﻿language: cpp
+language: cpp
 sudo: false
 
 addons:
@@ -11,4 +11,3 @@ addons:
 before_script: ls
 
 script: qmake demo/QtGoodiesDemo/QtGoodiesDemo.pro && make
-


### PR DESCRIPTION
I saw your question on StackOverflow:

http://stackoverflow.com/questions/33085443/travis-for-c-always-ignore-script-for-customize-testing

It seems you had a special hidden character in your .travis.yml file that prevented Travis CI to parse it properly.
